### PR TITLE
Add cvar to allow changing loadouts at any time

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ so they can choose a valid loadout. The player will then receive this weapon pos
 ## Installation
 * Move the compiled .smx binary to `addons/sourcemod/plugins`
 * Move the gamedata file to `addons/sourcemod/gamedata/neotokyo` (create the *"neotokyo"* folder in gamedata if it doesn't exist yet)
+
+## Configuration
+
+#### Cvars
+
+* *sm_loadout_rescue_allow_loadout_change*
+  * Whether to allow already spawned players to swap their loadout at any time. Useful for DM style modes.
+  * default: `0`, min: `0`, max: `1`

--- a/addons/sourcemod/scripting/nt_loadout_rescue.sp
+++ b/addons/sourcemod/scripting/nt_loadout_rescue.sp
@@ -83,6 +83,8 @@ Useful for DM style modes.", _, true, 0.0, true, 1.0);
     {
         SetFailState("Failed to hook event");
     }
+
+    AutoExecConfig();
 }
 
 #if SOURCEMOD_V_MAJOR == 1 && SOURCEMOD_V_MINOR < 11


### PR DESCRIPTION
Add cvar "sm_loadout_rescue_allow_loadout_change" for allowing players
to change their loadout even after spawning (still within their unlocked XP
range).

Players can choose weapons from the VGUI with the client command `loadoutmenu`, or directly with the `loadout n` commands, where n is the 1-based index of the desired loadout.

If the player is carrying a previous primary weapon, it will be deleted (with the exception of the ghost, which will be dropped instead) before giving them the new loadout.